### PR TITLE
Minor optimizations

### DIFF
--- a/IkiWiki/Plugin/mathjax.pm
+++ b/IkiWiki/Plugin/mathjax.pm
@@ -62,7 +62,7 @@ sub _scripttag {
     return '<script type="text/x-mathjax-config">'
       . 'MathJax.Hub.Config({ TeX: { equationNumbers: {autoNumber: "AMS"} } });'
       . '</script>'
-      . '<script type="text/javascript" '
+      . '<script async="async" type="text/javascript" '
       . 'src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config='
       . $config
       . '"></script>';


### PR DESCRIPTION
Hi.

First of all, thanks for writing this plugin for Ikiwiki in the first place. I can't live without typesetting math on my blog, and this is a missing piece that I'd love to have out-of-the-box.

Nevertheless, here are some minor optimizations to the generated HTML code for the plugin. The intent is to defer loading JavaScript as much as possible when loading the page, for the sake of making things parallel.

I know that the mathjax tutorials recommend that you load the JavaScript right there in the header, but, in my humble experience, I have not had problems with putting this as late as possible with my own blog (you can check it out at http://cynic.cc/blog/).

Please, consider merging these changes.

Thanks,

Rogério Brito.
