### PR TITLE
change the mathjax script CDN provider

### DIFF
--- a/IkiWiki/Plugin/mathjax.pm
+++ b/IkiWiki/Plugin/mathjax.pm
@@ -63,7 +63,7 @@ sub _scripttag {
       . 'MathJax.Hub.Config({ TeX: { equationNumbers: {autoNumber: "AMS"} } });'
       . '</script>'
       . '<script async="async" type="text/javascript" '
-      . 'src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config='
+      . 'src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config='
       . $config
       . '"></script>';
 }


### PR DESCRIPTION
MathJax shut down their CDN and suggested to migrate to other alternatives. The current version of the MathJax script hosted in the CDN being shutdown is just a proxy script to one of the options located at https://cdnjs.com.

More information is available here: https://www.mathjax.org/cdn-shutting-down/.
