### PR TITLE
fix _escape_mathjax when using mathjax plugin with org-mode plugin

### DIFF
--- a/IkiWiki/Plugin/mathjax.pm
+++ b/IkiWiki/Plugin/mathjax.pm
@@ -52,8 +52,8 @@ sub _escape_mathjax {
     $formula =~ s/&/&amp;/g; #"/}[{
     $formula =~ s/</&lt;/g;
     $formula =~ s/>/&gt;/g; #{"
-    $directive .= encode_base64($formula);
-    $directive .= " !!mathjaxend-$mode!!";
+    $directive .= encode_base64($formula, " ");
+    $directive .= "!!mathjaxend-$mode!!";
     return $directive;
 }
 


### PR DESCRIPTION
The function encode_base64, used by the _escape_mathjax function, by default returns the encoded string + '\n'. This newline character created problems when transforming files written in org-mode to HTML.

So, if we had something like this in org-mode:

```
- Using the formula below:
    $$h = \sum^{keylength}_{i=0} 128^i \times char(key[i])$$.
```
The plugin escapes the text above to something like:

```
- Using the formula below:
!!mathjaxbegin-d!! TygxKQ==
!!mathjaxend-d!!
```

The org-mode plugin would translate this to 

```
<ul class="org-ul">
<li>Using the formula below:</li>
</ul>
<p>
!!!!mathjaxbegin-d!! TygxKQ==
</p></li>
</ul>
<p>
!!mathjaxend-d!!
</p>
```

After processing this to transform to the actual math formulas, the HTML tags between the encoded string and `!!mathjaxend-d!!` delimiter are removed. Thus, rendering a mal-formed HTML.

With the fix, the escaped formula is now in a single line:

```
- Using the formula below:
!!mathjaxbegin-d!! TygxKQ== !!mathjaxend-d!!
```

This prevents the insertion of HTML tags by the org-mode plugin, and consequently the malformed HTML.